### PR TITLE
Implement Client.Stats().

### DIFF
--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestEnqueueOnlyType(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
 		t.Fatal(err)
@@ -47,7 +47,7 @@ func TestEnqueueOnlyType(t *testing.T) {
 
 func TestEnqueueWithPriority(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	want := int16(99)
 	if err := c.Enqueue(&Job{Type: "MyJob", Priority: want}); err != nil {
@@ -66,7 +66,7 @@ func TestEnqueueWithPriority(t *testing.T) {
 
 func TestEnqueueWithRunAt(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	want := time.Now().Add(2 * time.Minute)
 	if err := c.Enqueue(&Job{Type: "MyJob", RunAt: want}); err != nil {
@@ -87,7 +87,7 @@ func TestEnqueueWithRunAt(t *testing.T) {
 
 func TestEnqueueWithArgs(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	want := `{"arg1":0, "arg2":"a string"}`
 	if err := c.Enqueue(&Job{Type: "MyJob", Args: []byte(want)}); err != nil {
@@ -106,7 +106,7 @@ func TestEnqueueWithArgs(t *testing.T) {
 
 func TestEnqueueWithQueue(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	want := "special-work-queue"
 	if err := c.Enqueue(&Job{Type: "MyJob", Queue: want}); err != nil {
@@ -125,7 +125,7 @@ func TestEnqueueWithQueue(t *testing.T) {
 
 func TestEnqueueWithEmptyType(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	if err := c.Enqueue(&Job{Type: ""}); err != ErrMissingType {
 		t.Fatalf("want ErrMissingType, got %v", err)
@@ -134,7 +134,7 @@ func TestEnqueueWithEmptyType(t *testing.T) {
 
 func TestEnqueueInTx(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	tx, err := c.pool.Begin()
 	if err != nil {

--- a/que_test.go
+++ b/que_test.go
@@ -47,14 +47,20 @@ func openTestClientMaxConns(t testing.TB, maxConnections int) *Client {
 	db.SetMaxIdleConns(maxConnections)
 	// make lifetime sufficiently long
 	db.SetConnMaxLifetime(time.Duration(5 * time.Minute))
-	return NewClient(db)
+	c, err := NewClient2(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
 }
 
 func openTestClient(t testing.TB) *Client {
 	return openTestClientMaxConns(t, maxConn)
 }
 
-func truncateAndClose(pool *sql.DB) {
+func truncateAndClose(c *Client) {
+	pool := c.pool
+	c.Close()
 	if _, err := pool.Exec("TRUNCATE TABLE que_jobs"); err != nil {
 		panic(err)
 	}

--- a/sql.go
+++ b/sql.go
@@ -114,7 +114,7 @@ LEFT JOIN (
   WHERE locktype = 'advisory'
 ) locks USING (job_id)
 GROUP BY queue, job_class
-ORDER BY count(*) DESC
+ORDER BY queue, job_class
 `
 
 	sqlWorkerStates = `

--- a/stats_test.go
+++ b/stats_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestStats(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	if err := c.Enqueue(&Job{Queue: "Q1", Type: "MyJob"}); err != nil {
 		t.Fatal(err)

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,573 @@
+package qg
+
+import (
+	"testing"
+)
+
+func TestStats(t *testing.T) {
+	c := openTestClient(t)
+	defer truncateAndClose(c.pool)
+
+	if err := c.Enqueue(&Job{Queue: "Q1", Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := c.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if 1 != len(stats) {
+		t.Errorf("1 != len(stats) (got %v)", len(stats))
+	}
+
+	if "Q1" != stats[0].Queue {
+		t.Errorf("\"Q1\" != stats[0].Queue (got %v)", stats[0].Queue)
+	}
+
+	if "MyJob" != stats[0].Type {
+		t.Errorf("\"MyJob\" != stats[0].Type (got %v)", stats[0].Type)
+	}
+
+	if 1 != stats[0].Count {
+		t.Errorf("1 != stats[0].Count (got %v)", stats[0].Count)
+	}
+
+	if 0 != stats[0].CountWorking {
+		t.Errorf("0 != stats[0].CountWorking (got %v)", stats[0].CountWorking)
+	}
+
+	if 0 != stats[0].CountErrored {
+		t.Errorf("0 != stats[0].CountErrored (got %v)", stats[0].CountErrored)
+	}
+
+	if 0 != stats[0].HighestErrorCount {
+		t.Errorf("0 != stats[0].HighestErrorCount (got %v)", stats[0].HighestErrorCount)
+	}
+
+	if stats[0].OldestRunAt.IsZero() {
+		t.Errorf("false != stats[0].OldestRunAt.IsZero() (got %v)", stats[0].OldestRunAt.IsZero())
+	}
+
+	if err := c.Enqueue(&Job{Queue: "Q1", Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err = c.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if 1 != len(stats) {
+		t.Errorf("1 != len(stats) (got %v)", len(stats))
+	}
+
+	if "Q1" != stats[0].Queue {
+		t.Errorf("\"Q1\" != stats[0].Queue (got %v)", stats[0].Queue)
+	}
+
+	if "MyJob" != stats[0].Type {
+		t.Errorf("\"MyJob\" != stats[0].Type (got %v)", stats[0].Type)
+	}
+
+	if 2 != stats[0].Count {
+		t.Errorf("1 != stats[0].Count (got %v)", stats[0].Count)
+	}
+
+	if 0 != stats[0].CountWorking {
+		t.Errorf("0 != stats[0].CountWorking (got %v)", stats[0].CountWorking)
+	}
+
+	if 0 != stats[0].CountErrored {
+		t.Errorf("0 != stats[0].CountErrored (got %v)", stats[0].CountErrored)
+	}
+
+	if 0 != stats[0].HighestErrorCount {
+		t.Errorf("0 != stats[0].HighestErrorCount (got %v)", stats[0].HighestErrorCount)
+	}
+
+	if stats[0].OldestRunAt.IsZero() {
+		t.Errorf("false != stats[0].OldestRunAt.IsZero() (got %v)", stats[0].OldestRunAt.IsZero())
+	}
+
+	if err := c.Enqueue(&Job{Queue: "Q2", Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err = c.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if 2 != len(stats) {
+		t.Errorf("1 != len(stats) (got %v)", len(stats))
+	}
+
+	if "Q1" != stats[0].Queue {
+		t.Errorf("\"Q1\" != stats[0].Queue (got %v)", stats[0].Queue)
+	}
+
+	if "MyJob" != stats[0].Type {
+		t.Errorf("\"MyJob\" != stats[0].Type (got %v)", stats[0].Type)
+	}
+
+	if 2 != stats[0].Count {
+		t.Errorf("1 != stats[0].Count (got %v)", stats[0].Count)
+	}
+
+	if 0 != stats[0].CountWorking {
+		t.Errorf("0 != stats[0].CountWorking (got %v)", stats[0].CountWorking)
+	}
+
+	if 0 != stats[0].CountErrored {
+		t.Errorf("0 != stats[0].CountErrored (got %v)", stats[0].CountErrored)
+	}
+
+	if 0 != stats[0].HighestErrorCount {
+		t.Errorf("0 != stats[0].HighestErrorCount (got %v)", stats[0].HighestErrorCount)
+	}
+
+	if stats[0].OldestRunAt.IsZero() {
+		t.Errorf("false != stats[0].OldestRunAt.IsZero() (got %v)", stats[0].OldestRunAt.IsZero())
+	}
+
+	if "Q2" != stats[1].Queue {
+		t.Errorf("\"Q2\" != stats[1].Queue (got %v)", stats[1].Queue)
+	}
+
+	if "MyJob" != stats[1].Type {
+		t.Errorf("\"MyJob\" != stats[1].Type (got %v)", stats[1].Type)
+	}
+
+	if 1 != stats[1].Count {
+		t.Errorf("1 != stats[1].Count (got %v)", stats[1].Count)
+	}
+
+	if 0 != stats[1].CountWorking {
+		t.Errorf("0 != stats[1].CountWorking (got %v)", stats[1].CountWorking)
+	}
+
+	if 0 != stats[1].CountErrored {
+		t.Errorf("0 != stats[1].CountErrored (got %v)", stats[1].CountErrored)
+	}
+
+	if 0 != stats[1].HighestErrorCount {
+		t.Errorf("0 != stats[1].HighestErrorCount (got %v)", stats[1].HighestErrorCount)
+	}
+
+	if stats[1].OldestRunAt.IsZero() {
+		t.Errorf("false != stats[1].OldestRunAt.IsZero() (got %v)", stats[1].OldestRunAt.IsZero())
+	}
+
+	if err := c.Enqueue(&Job{Queue: "Q1", Type: "AnotherJob"}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err = c.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if 3 != len(stats) {
+		t.Errorf("3 != len(stats) (got %v)", len(stats))
+	}
+
+	if "Q1" != stats[0].Queue {
+		t.Errorf("\"Q1\" != stats[0].Queue (got %v)", stats[0].Queue)
+	}
+
+	if "AnotherJob" != stats[0].Type {
+		t.Errorf("\"AnotherJob\" != stats[0].Type (got %v)", stats[0].Type)
+	}
+
+	if 1 != stats[0].Count {
+		t.Errorf("1 != stats[0].Count (got %v)", stats[0].Count)
+	}
+
+	if 0 != stats[0].CountWorking {
+		t.Errorf("0 != stats[0].CountWorking (got %v)", stats[0].CountWorking)
+	}
+
+	if 0 != stats[0].CountErrored {
+		t.Errorf("0 != stats[0].CountErrored (got %v)", stats[0].CountErrored)
+	}
+
+	if 0 != stats[0].HighestErrorCount {
+		t.Errorf("0 != stats[0].HighestErrorCount (got %v)", stats[0].HighestErrorCount)
+	}
+
+	if stats[0].OldestRunAt.IsZero() {
+		t.Errorf("false != stats[0].OldestRunAt.IsZero() (got %v)", stats[0].OldestRunAt.IsZero())
+	}
+
+	if "Q1" != stats[1].Queue {
+		t.Errorf("\"Q1\" != stats[1].Queue (got %v)", stats[1].Queue)
+	}
+
+	if "MyJob" != stats[1].Type {
+		t.Errorf("\"MyJob\" != stats[1].Type (got %v)", stats[1].Type)
+	}
+
+	if 2 != stats[1].Count {
+		t.Errorf("1 != stats[1].Count (got %v)", stats[1].Count)
+	}
+
+	if 0 != stats[1].CountWorking {
+		t.Errorf("0 != stats[1].CountWorking (got %v)", stats[1].CountWorking)
+	}
+
+	if 0 != stats[1].CountErrored {
+		t.Errorf("0 != stats[1].CountErrored (got %v)", stats[1].CountErrored)
+	}
+
+	if 0 != stats[1].HighestErrorCount {
+		t.Errorf("0 != stats[1].HighestErrorCount (got %v)", stats[1].HighestErrorCount)
+	}
+
+	if stats[0].OldestRunAt.IsZero() {
+		t.Errorf("false != stats[0].OldestRunAt.IsZero() (got %v)", stats[0].OldestRunAt.IsZero())
+	}
+
+	if "Q2" != stats[2].Queue {
+		t.Errorf("\"Q2\" != stats[2].Queue (got %v)", stats[2].Queue)
+	}
+
+	if "MyJob" != stats[2].Type {
+		t.Errorf("\"MyJob\" != stats[2].Type (got %v)", stats[2].Type)
+	}
+
+	if 1 != stats[2].Count {
+		t.Errorf("1 != stats[2].Count (got %v)", stats[2].Count)
+	}
+
+	if 0 != stats[2].CountWorking {
+		t.Errorf("0 != stats[2].CountWorking (got %v)", stats[2].CountWorking)
+	}
+
+	if 0 != stats[2].CountErrored {
+		t.Errorf("0 != stats[2].CountErrored (got %v)", stats[2].CountErrored)
+	}
+
+	if 0 != stats[2].HighestErrorCount {
+		t.Errorf("0 != stats[2].HighestErrorCount (got %v)", stats[2].HighestErrorCount)
+	}
+
+	if stats[2].OldestRunAt.IsZero() {
+		t.Errorf("false != stats[2].OldestRunAt.IsZero() (got %v)", stats[2].OldestRunAt.IsZero())
+	}
+
+	func() {
+		j, err := c.LockJob("Q1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if j == nil {
+			t.Fatal(err)
+		}
+		defer j.Done()
+
+		stats, err = c.Stats()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if 3 != len(stats) {
+			t.Errorf("3 != len(stats) (got %v)", len(stats))
+		}
+
+		if "Q1" != stats[0].Queue {
+			t.Errorf("\"Q1\" != stats[0].Queue (got %v)", stats[0].Queue)
+		}
+
+		if "AnotherJob" != stats[0].Type {
+			t.Errorf("\"AnotherJob\" != stats[0].Type (got %v)", stats[0].Type)
+		}
+
+		if 1 != stats[0].Count {
+			t.Errorf("1 != stats[0].Count (got %v)", stats[0].Count)
+		}
+
+		if 0 != stats[0].CountWorking {
+			t.Errorf("0 != stats[0].CountWorking (got %v)", stats[0].CountWorking)
+		}
+
+		if 0 != stats[0].CountErrored {
+			t.Errorf("0 != stats[0].CountErrored (got %v)", stats[0].CountErrored)
+		}
+
+		if 0 != stats[0].HighestErrorCount {
+			t.Errorf("0 != stats[0].HighestErrorCount (got %v)", stats[0].HighestErrorCount)
+		}
+
+		if stats[0].OldestRunAt.IsZero() {
+			t.Errorf("false != stats[0].OldestRunAt.IsZero() (got %v)", stats[0].OldestRunAt.IsZero())
+		}
+
+		if "Q1" != stats[1].Queue {
+			t.Errorf("\"Q1\" != stats[1].Queue (got %v)", stats[1].Queue)
+		}
+
+		if "MyJob" != stats[1].Type {
+			t.Errorf("\"MyJob\" != stats[1].Type (got %v)", stats[1].Type)
+		}
+
+		if 2 != stats[1].Count {
+			t.Errorf("1 != stats[1].Count (got %v)", stats[1].Count)
+		}
+
+		if 1 != stats[1].CountWorking {
+			t.Errorf("1 != stats[1].CountWorking (got %v)", stats[1].CountWorking)
+		}
+
+		if 0 != stats[1].CountErrored {
+			t.Errorf("0 != stats[1].CountErrored (got %v)", stats[1].CountErrored)
+		}
+
+		if 0 != stats[1].HighestErrorCount {
+			t.Errorf("0 != stats[1].HighestErrorCount (got %v)", stats[1].HighestErrorCount)
+		}
+
+		if stats[0].OldestRunAt.IsZero() {
+			t.Errorf("false != stats[0].OldestRunAt.IsZero() (got %v)", stats[0].OldestRunAt.IsZero())
+		}
+
+		if "Q2" != stats[2].Queue {
+			t.Errorf("\"Q2\" != stats[2].Queue (got %v)", stats[2].Queue)
+		}
+
+		if "MyJob" != stats[2].Type {
+			t.Errorf("\"MyJob\" != stats[2].Type (got %v)", stats[2].Type)
+		}
+
+		if 1 != stats[2].Count {
+			t.Errorf("1 != stats[2].Count (got %v)", stats[2].Count)
+		}
+
+		if 0 != stats[2].CountWorking {
+			t.Errorf("0 != stats[2].CountWorking (got %v)", stats[2].CountWorking)
+		}
+
+		if 0 != stats[2].CountErrored {
+			t.Errorf("0 != stats[2].CountErrored (got %v)", stats[2].CountErrored)
+		}
+
+		if 0 != stats[2].HighestErrorCount {
+			t.Errorf("0 != stats[2].HighestErrorCount (got %v)", stats[2].HighestErrorCount)
+		}
+
+		if stats[2].OldestRunAt.IsZero() {
+			t.Errorf("false != stats[2].OldestRunAt.IsZero() (got %v)", stats[2].OldestRunAt.IsZero())
+		}
+	}()
+
+	func() {
+		j, err := c.LockJob("Q1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if j == nil {
+			t.Fatal(err)
+		}
+		defer j.Done()
+		j.Delete()
+
+		stats, err = c.Stats()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if 3 != len(stats) {
+			t.Errorf("3 != len(stats) (got %v)", len(stats))
+		}
+
+		if "Q1" != stats[0].Queue {
+			t.Errorf("\"Q1\" != stats[0].Queue (got %v)", stats[0].Queue)
+		}
+
+		if "AnotherJob" != stats[0].Type {
+			t.Errorf("\"AnotherJob\" != stats[0].Type (got %v)", stats[0].Type)
+		}
+
+		if 1 != stats[0].Count {
+			t.Errorf("1 != stats[0].Count (got %v)", stats[0].Count)
+		}
+
+		if 0 != stats[0].CountWorking {
+			t.Errorf("0 != stats[0].CountWorking (got %v)", stats[0].CountWorking)
+		}
+
+		if 0 != stats[0].CountErrored {
+			t.Errorf("0 != stats[0].CountErrored (got %v)", stats[0].CountErrored)
+		}
+
+		if 0 != stats[0].HighestErrorCount {
+			t.Errorf("0 != stats[0].HighestErrorCount (got %v)", stats[0].HighestErrorCount)
+		}
+
+		if stats[0].OldestRunAt.IsZero() {
+			t.Errorf("false != stats[0].OldestRunAt.IsZero() (got %v)", stats[0].OldestRunAt.IsZero())
+		}
+
+		if "Q1" != stats[1].Queue {
+			t.Errorf("\"Q1\" != stats[1].Queue (got %v)", stats[1].Queue)
+		}
+
+		if "MyJob" != stats[1].Type {
+			t.Errorf("\"MyJob\" != stats[1].Type (got %v)", stats[1].Type)
+		}
+
+		if 1 != stats[1].Count {
+			t.Errorf("1 != stats[1].Count (got %v)", stats[1].Count)
+		}
+
+		if 0 != stats[1].CountWorking {
+			t.Errorf("0 != stats[1].CountWorking (got %v)", stats[1].CountWorking)
+		}
+
+		if 0 != stats[1].CountErrored {
+			t.Errorf("0 != stats[1].CountErrored (got %v)", stats[1].CountErrored)
+		}
+
+		if 0 != stats[1].HighestErrorCount {
+			t.Errorf("0 != stats[1].HighestErrorCount (got %v)", stats[1].HighestErrorCount)
+		}
+
+		if stats[0].OldestRunAt.IsZero() {
+			t.Errorf("false != stats[0].OldestRunAt.IsZero() (got %v)", stats[0].OldestRunAt.IsZero())
+		}
+
+		if "Q2" != stats[2].Queue {
+			t.Errorf("\"Q2\" != stats[2].Queue (got %v)", stats[2].Queue)
+		}
+
+		if "MyJob" != stats[2].Type {
+			t.Errorf("\"MyJob\" != stats[2].Type (got %v)", stats[2].Type)
+		}
+
+		if 1 != stats[2].Count {
+			t.Errorf("1 != stats[2].Count (got %v)", stats[2].Count)
+		}
+
+		if 0 != stats[2].CountWorking {
+			t.Errorf("0 != stats[2].CountWorking (got %v)", stats[2].CountWorking)
+		}
+
+		if 0 != stats[2].CountErrored {
+			t.Errorf("0 != stats[2].CountErrored (got %v)", stats[2].CountErrored)
+		}
+
+		if 0 != stats[2].HighestErrorCount {
+			t.Errorf("0 != stats[2].HighestErrorCount (got %v)", stats[2].HighestErrorCount)
+		}
+
+		if stats[2].OldestRunAt.IsZero() {
+			t.Errorf("false != stats[2].OldestRunAt.IsZero() (got %v)", stats[2].OldestRunAt.IsZero())
+		}
+	}()
+
+	func() {
+		j, err := c.LockJob("Q1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if j == nil {
+			t.Fatal(err)
+		}
+		j.Error("???")
+		j.Done()
+
+		stats, err = c.Stats()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if 3 != len(stats) {
+			t.Errorf("3 != len(stats) (got %v)", len(stats))
+		}
+
+		if "Q1" != stats[0].Queue {
+			t.Errorf("\"Q1\" != stats[0].Queue (got %v)", stats[0].Queue)
+		}
+
+		if "AnotherJob" != stats[0].Type {
+			t.Errorf("\"AnotherJob\" != stats[0].Type (got %v)", stats[0].Type)
+		}
+
+		if 1 != stats[0].Count {
+			t.Errorf("1 != stats[0].Count (got %v)", stats[0].Count)
+		}
+
+		if 0 != stats[0].CountWorking {
+			t.Errorf("0 != stats[0].CountWorking (got %v)", stats[0].CountWorking)
+		}
+
+		if 0 != stats[0].CountErrored {
+			t.Errorf("0 != stats[0].CountErrored (got %v)", stats[0].CountErrored)
+		}
+
+		if 0 != stats[0].HighestErrorCount {
+			t.Errorf("0 != stats[0].HighestErrorCount (got %v)", stats[0].HighestErrorCount)
+		}
+
+		if stats[0].OldestRunAt.IsZero() {
+			t.Errorf("false != stats[0].OldestRunAt.IsZero() (got %v)", stats[0].OldestRunAt.IsZero())
+		}
+
+		if "Q1" != stats[1].Queue {
+			t.Errorf("\"Q1\" != stats[1].Queue (got %v)", stats[1].Queue)
+		}
+
+		if "MyJob" != stats[1].Type {
+			t.Errorf("\"MyJob\" != stats[1].Type (got %v)", stats[1].Type)
+		}
+
+		if 1 != stats[1].Count {
+			t.Errorf("1 != stats[1].Count (got %v)", stats[1].Count)
+		}
+
+		if 0 != stats[1].CountWorking {
+			t.Errorf("0 != stats[1].CountWorking (got %v)", stats[1].CountWorking)
+		}
+
+		if 1 != stats[1].CountErrored {
+			t.Errorf("1 != stats[1].CountErrored (got %v)", stats[1].CountErrored)
+		}
+
+		if 1 != stats[1].HighestErrorCount {
+			t.Errorf("1 != stats[1].HighestErrorCount (got %v)", stats[1].HighestErrorCount)
+		}
+
+		if stats[0].OldestRunAt.IsZero() {
+			t.Errorf("false != stats[0].OldestRunAt.IsZero() (got %v)", stats[0].OldestRunAt.IsZero())
+		}
+
+		if "Q2" != stats[2].Queue {
+			t.Errorf("\"Q2\" != stats[2].Queue (got %v)", stats[2].Queue)
+		}
+
+		if "MyJob" != stats[2].Type {
+			t.Errorf("\"MyJob\" != stats[2].Type (got %v)", stats[2].Type)
+		}
+
+		if 1 != stats[2].Count {
+			t.Errorf("1 != stats[2].Count (got %v)", stats[2].Count)
+		}
+
+		if 0 != stats[2].CountWorking {
+			t.Errorf("0 != stats[2].CountWorking (got %v)", stats[2].CountWorking)
+		}
+
+		if 0 != stats[2].CountErrored {
+			t.Errorf("0 != stats[2].CountErrored (got %v)", stats[2].CountErrored)
+		}
+
+		if 0 != stats[2].HighestErrorCount {
+			t.Errorf("0 != stats[2].HighestErrorCount (got %v)", stats[2].HighestErrorCount)
+		}
+
+		if stats[2].OldestRunAt.IsZero() {
+			t.Errorf("false != stats[2].OldestRunAt.IsZero() (got %v)", stats[2].OldestRunAt.IsZero())
+		}
+	}()
+
+}

--- a/testing.go
+++ b/testing.go
@@ -1,10 +1,10 @@
 package qg
 
-import "database/sql"
+import "github.com/jackc/pgx"
 
-// TestInjectJobConn injects *pgx.Conn to Job
-func TestInjectJobConn(j *Job, conn *sql.DB) *Job {
-	j.pool = conn
+// // TestInjectJobConn injects *pgx.Conn to Job
+func TestInjectJobConn(j *Job, conn *pgx.Conn) *Job {
+	j.conn = conn
 	return j
 }
 

--- a/worker.go
+++ b/worker.go
@@ -95,7 +95,7 @@ func (w *Worker) WorkOne() (didWork bool) {
 	if j == nil {
 		return // no job was available
 	}
-	j.tx, err = j.pool.Begin()
+	j.tx, err = j.c.pool.Begin()
 	if err != nil {
 		log.Printf("failed to create transaction: %v", err)
 		return

--- a/worker_test.go
+++ b/worker_test.go
@@ -15,7 +15,7 @@ func init() {
 
 func TestWorkerWorkOne(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	success := false
 	wm := WorkMap{
@@ -46,7 +46,7 @@ func TestWorkerWorkOne(t *testing.T) {
 
 func TestWorkerShutdown(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	w := NewWorker(c, WorkMap{})
 	finished := false
@@ -69,7 +69,7 @@ func BenchmarkWorker(b *testing.B) {
 	defer func() {
 		log.SetOutput(os.Stdout)
 	}()
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	w := NewWorker(c, WorkMap{"Nil": nilWorker})
 
@@ -91,7 +91,7 @@ func nilWorker(j *Job) error {
 
 func TestWorkerWorkReturnsError(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	called := 0
 	wm := WorkMap{
@@ -142,7 +142,7 @@ func TestWorkerWorkReturnsError(t *testing.T) {
 
 func TestWorkerWorkRescuesPanic(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	called := 0
 	wm := WorkMap{
@@ -193,7 +193,7 @@ func TestWorkerWorkRescuesPanic(t *testing.T) {
 
 func TestWorkerWorkOneTypeNotInMap(t *testing.T) {
 	c := openTestClient(t)
-	defer truncateAndClose(c.pool)
+	defer truncateAndClose(c)
 
 	currentConns := 2
 	availConns := 2


### PR DESCRIPTION
* This implements `Client.Stats()` that is roughly equivalent to `Que::Utils::Introspection.job_stats` in que.
* The result is sorted by `queue` and `job_class` in ascending order, which is different from Que (it sorts the result by the job count in descending order)
* New function `NewClient2()` is introduced, as it can now signal an error.
* Accordingly, `Client.Close()` is introduced.  One should call it on cleanup, but it is optional if she wants the same behavior as before this patch.

