### PR TITLE
Add conn release

### DIFF
--- a/que.go
+++ b/que.go
@@ -381,6 +381,7 @@ func (c *Client) LockJob(queue string) (*Job, error) {
 			return nil, err
 		}
 	}
+	stdlib.ReleaseConn(c.pool, conn)
 	return nil, ErrAgain
 }
 


### PR DESCRIPTION
Add connection release after failing to lock `maxLockJobAttempts` times to prevent deadlock