### PR TITLE
chore: Remove unused private constant

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -116,22 +116,4 @@ LEFT JOIN (
 GROUP BY queue, job_class
 ORDER BY queue, job_class
 `
-
-	sqlWorkerStates = `
-SELECT que_jobs.*,
-       pg.pid          AS pg_backend_pid,
-       pg.state        AS pg_state,
-       pg.state_change AS pg_state_changed_at,
-       pg.query        AS pg_last_query,
-       pg.query_start  AS pg_last_query_started_at,
-       pg.xact_start   AS pg_transaction_started_at,
-       pg.waiting      AS pg_waiting_on_lock
-FROM que_jobs
-JOIN (
-  SELECT (classid::bigint << 32) + objid::bigint AS job_id, pg_stat_activity.*
-  FROM pg_locks
-  JOIN pg_stat_activity USING (pid)
-  WHERE locktype = 'advisory'
-) pg USING (job_id)
-`
 )


### PR DESCRIPTION
Delete the constant `sqlWorkerStates` because it is not used anywhere.
@achiku Please review the PR.