### PR TITLE
Add finished_at to que_jobs

### DIFF
--- a/que.go
+++ b/que.go
@@ -109,7 +109,7 @@ func (j *Job) Tx() Txer {
 //
 // You must also later call Done() to return this job's database connection to
 // the pool.
-func (j *Job) Delete() error {
+func (j *Job) Finish() error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
@@ -117,7 +117,7 @@ func (j *Job) Delete() error {
 		return nil
 	}
 
-	_, err := j.conn.Exec("que_destroy_job", j.Queue, j.Priority, j.RunAt, j.ID)
+	_, err := j.conn.Exec("que_finish_job", j.Queue, j.Priority, j.RunAt, j.ID, time.Now())
 	if err != nil {
 		return err
 	}
@@ -386,12 +386,12 @@ func (c *Client) LockJob(queue string) (*Job, error) {
 }
 
 var preparedStatements = map[string]string{
-	"que_check_job":   sqlCheckJob,
-	"que_destroy_job": sqlDeleteJob,
-	"que_insert_job":  sqlInsertJob,
-	"que_lock_job":    sqlLockJob,
-	"que_set_error":   sqlSetError,
-	"que_unlock_job":  sqlUnlockJob,
+	"que_check_job":  sqlCheckJob,
+	"que_finish_job": sqlFinishJob,
+	"que_insert_job": sqlInsertJob,
+	"que_lock_job":   sqlLockJob,
+	"que_set_error":  sqlSetError,
+	"que_unlock_job": sqlUnlockJob,
 }
 
 // PrepareStatements prepar statements

--- a/que_test.go
+++ b/que_test.go
@@ -72,7 +72,9 @@ func truncateAndClose(c *Client) {
 func findOneJob(q Queryer) (*Job, error) {
 	findSQL := `
 	SELECT priority, run_at, job_id, job_class, args, error_count, last_error, queue
-	FROM que_jobs LIMIT 1`
+	FROM que_jobs
+	WHERE finished_at IS NULL
+	LIMIT 1`
 
 	j := &Job{}
 	err := q.QueryRow(findSQL).Scan(

--- a/schema.sql
+++ b/schema.sql
@@ -13,3 +13,5 @@ CREATE TABLE que_jobs
 );
 
 COMMENT ON TABLE que_jobs IS '3';
+ALTER TABLE que_jobs ADD finished_at timestamptz;
+CREATE INDEX idx_que_jobs_finished_at ON que_jobs (finished_at);

--- a/stats_test.go
+++ b/stats_test.go
@@ -369,7 +369,7 @@ func TestStats(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer j.Done()
-		j.Delete()
+		j.Finish()
 
 		stats, err = c.Stats()
 		if err != nil {

--- a/work_test.go
+++ b/work_test.go
@@ -75,7 +75,7 @@ func TestLockJob(t *testing.T) {
 		t.Errorf("want available=%d, got %d", want, available)
 	}
 
-	if err = j.Delete(); err != nil {
+	if err = j.Finish(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -147,7 +147,7 @@ func TestLockJobCustomQueue(t *testing.T) {
 		t.Fatal("wanted job, got none")
 	}
 
-	if err = j.Delete(); err != nil {
+	if err = j.Finish(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -394,7 +394,7 @@ func TestJobDelete(t *testing.T) {
 	}
 	defer j.Done()
 
-	if err = j.Delete(); err != nil {
+	if err = j.Finish(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -503,7 +503,7 @@ func TestJobDeleteFromTx(t *testing.T) {
 	}
 
 	// delete the job
-	if err = j.Delete(); err != nil {
+	if err = j.Finish(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -554,7 +554,7 @@ func TestJobDeleteFromTxRollback(t *testing.T) {
 	}
 
 	// delete the job
-	if err = j1.Delete(); err != nil {
+	if err = j1.Finish(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/worker.go
+++ b/worker.go
@@ -129,7 +129,7 @@ func (w *Worker) WorkOne() (didWork bool) {
 		return
 	}
 
-	if err = j.Delete(); err != nil {
+	if err = j.Finish(); err != nil {
 		log.Printf("attempting to delete job %d: %v", j.ID, err)
 	}
 	j.tx.Commit()


### PR DESCRIPTION
## Description

Add a `finished_at` column to the `que_jobs` table to know the finished status.

## Why?

This is because job information should not be deleted, including "finished" information.
Outputting status to a log is an option, but logs are not as reliable as databases.

## Queue cleaning

Jobs will remain in the queue and will need to be cleaned.
I consider this a necessary cost.

@achiku Could you please review?