### PR TITLE
add PrepareContext to Queryer

### DIFF
--- a/que.go
+++ b/que.go
@@ -58,6 +58,7 @@ type Job struct {
 type Queryer interface {
 	Exec(string, ...interface{}) (sql.Result, error)
 	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	PrepareContext(context.Context, string) (*sql.Stmt, error)
 	Query(string, ...interface{}) (*sql.Rows, error)
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRow(string, ...interface{}) *sql.Row


### PR DESCRIPTION
qg.Job.Tx()が返すTxerを以下のNew()に渡す際に `PrepareContext`が必要となるので、追加しました。

```
// Code generated by sqlc. DO NOT EDIT.

package model

import (
	"context"
	"database/sql"
)

type DBTX interface {
	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
	PrepareContext(context.Context, string) (*sql.Stmt, error)
	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
}

func New(db DBTX) *Queries {
	return &Queries{db: db}
}

type Queries struct {
	db DBTX
}
```