### PR TITLE
Update CI go version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,11 @@ jobs:
             # - macOS-latest
             # - windows-latest
         go:
+          - "1.21"
+          - "1.20"
           - "1.19"
           - "1.18"
           - "1.17"
-          - "1.16"
     services:
       postgres:
         image: postgres:12


### PR DESCRIPTION
Update CI go version.
Add 1.2x, Remove 1.16.

Please review @kanmu/developers 🙏 

- fix https://github.com/kanmu/qg/pull/19