### PR TITLE
Add module versioning for v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kanmu/qg
+module github.com/kanmu/qg/v3
 
 go 1.16
 


### PR DESCRIPTION
goはmajor updateをする場合はmodule名も変える必要があったのでメジャーバージョンを末尾につけました。

(本来↓のようにやるべきだった)
https://go.dev/blog/v2-go-modules