### PR TITLE
Bump up version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kanmu/qg
+module github.com/kanmu/qg/v4
 
 go 1.22.0
 


### PR DESCRIPTION
慣習に従って `/v4` のパスを追加します。

- [Go modulesでメジャーバージョンをv2以上に上げる時のハマりごと - aereal-tech](https://scrapbox.io/aereal-tech/Go_modules%E3%81%A7%E3%83%A1%E3%82%B8%E3%83%A3%E3%83%BC%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E3%82%92v2%E4%BB%A5%E4%B8%8A%E3%81%AB%E4%B8%8A%E3%81%92%E3%82%8B%E6%99%82%E3%81%AE%E3%83%8F%E3%83%9E%E3%82%8A%E3%81%94%E3%81%A8)
