### PR TITLE
testing.go -> testing_test.go

### DIFF
--- a/testing_test.go
+++ b/testing_test.go
@@ -1,6 +1,8 @@
 package qg
 
-import "database/sql"
+import (
+	"database/sql"
+)
 
 // // TestInjectJobConn injects *pgx.Conn to Job
 func TestInjectJobConn(j *Job, conn *sql.Conn) *Job {


### PR DESCRIPTION
テスト用の関数がパッケージに含まれてしまっているので、testing_test.goにリネームします

レビューをお願いします 🙏 